### PR TITLE
Changing order of discretization of colormap

### DIFF
--- a/cmocean.m
+++ b/cmocean.m
@@ -197,11 +197,6 @@ if negativeColormap
    cmap = colorspace('LAB->RGB',LAB); 
 end
 
-% Interpolate if necessary: 
-if NLevels~=size(cmap,1)
-   cmap = interp1(1:size(cmap,1), cmap, linspace(1,size(cmap,1),NLevels),'linear');
-end
-
 %% Invert the colormap if requested by user: 
 
 if InvertedColormap
@@ -215,6 +210,12 @@ if autopivot
    assert(PivotValue>=clim(1) & PivotValue<=clim(2),'Error: pivot value must be within the current color axis limits.') 
    maxval = max(abs(clim-PivotValue)); 
    cmap = interp1(linspace(-maxval,maxval,size(cmap,1))+PivotValue, cmap, linspace(clim(1),clim(2),size(cmap,1)),'linear');
+end
+
+%% Interpolate if necessary: 
+
+if NLevels~=size(cmap,1)
+   cmap = interp1(1:size(cmap,1), cmap, linspace(1,size(cmap,1),NLevels),'linear');
 end
 
 %% Clean up 


### PR DESCRIPTION
Problem: When using the pivot option, if the colormap is divided into a relatively small number of discrete elements before applying the pivot can lead to unintended colors around the pivot due to precision error of the discretization interpolation. This problem mainly becomes evident when you have highly imbalanced extents above and below the pivot, e.g., if caxis range is [-20,2] and pivot is at zero, as shown in example below.

Suggested Fix: Move the discretization of the colormap to the end of the `cmocean` function after the pivot is applied.

**Example**
`caxis([-20 2])`

- No discretization:
`cmocean('topo','pivot',0)`
<img width="65" alt="image" src="https://user-images.githubusercontent.com/21131934/127212429-888f23a8-f2b7-407e-93f5-a8d668f44c92.png">

- Discretization into 11 colors:
`cmocean('topo',11,'pivot',0)`

Before:
<img width="65" alt="image" src="https://user-images.githubusercontent.com/21131934/127212261-9cafed45-c191-4823-81d8-5a46f179cf06.png">
After:
<img width="65" alt="image" src="https://user-images.githubusercontent.com/21131934/127212225-92ad9a4a-f6ba-42a9-a5e6-65d013cef7d5.png">